### PR TITLE
Função geradora de chave pública finalizada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.o
 *.exe
 executavel
+
+# Gerado pelo programa
+ChavePublica.key

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Encriptador e descriptador de textos usando criptografia RSA.
 
 ### Como compilar (via terminal):
 
+	gcc -c chaves.c -o chaves.o
 	gcc -c chavePublica.c -o chavePublica.o
 	gcc -c criptografar.c -o criptografar.o
 	gcc -c descriptografar.c -o descriptografar.o

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Encriptador e descriptador de textos usando criptografia RSA.
 	gcc -c interface.c -o interface.o
 	gcc -c main.c -o main.o
 	gcc -c menu.c -o menu.o
-	gcc chavePublica.o criptografar.o descriptografar.o interface.o main.o menu.o -o executavel
+	gcc chaves.o chavePublica.o criptografar.o descriptografar.o interface.o main.o menu.o -o executavel
 
 ou:
 

--- a/chavePublica.c
+++ b/chavePublica.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
+#include "chaves.h"
 #include "chavePublica.h"
 #include "interface.h"
 
-void escreveChave(int n, int e);
 void chavePublica() {
-	int p, q, n, e;
+	int p, q, e;
 	i_chavePublica(1);
 	scanf("%d", &p);
 	i_chavePublica(2);
@@ -12,4 +12,6 @@ void chavePublica() {
 	i_chavePublica(3);
 	scanf("%d", &e);
 	i_chavePublica(4);
+	escreveChave(geraN(p, q), e);
+	i_chavePublica(5);
 }

--- a/chavePublica.h
+++ b/chavePublica.h
@@ -1,2 +1,1 @@
-void escreveChave(int n, int e);	//Escreve a chave publica em um arquivo de texto
 void chavePublica();				//Menu principal para gerar chave publica

--- a/chaves.c
+++ b/chaves.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "chaves.h"
+
+void escreveChave(int n, int e) {
+	FILE *chave = NULL;
+	char nomeDoArquivo[FILENAME_MAX] = "ChavePublica.key";
+	chave = fopen(nomeDoArquivo, "w+");
+	fprintf(chave, "(%d,%d)", n, e);
+	fclose(chave);
+}
+int geraN(int p, int q) {
+	return p * q;
+}

--- a/chaves.h
+++ b/chaves.h
@@ -1,0 +1,2 @@
+void escreveChave(int n, int e);	//Escreve a chave publica em um arquivo de texto
+int geraN(int p, int q);			//Calcula valor de n

--- a/compilador.sh
+++ b/compilador.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
+gcc -c chaves.c -o chaves.o
 gcc -c chavePublica.c -o chavePublica.o
 gcc -c criptografar.c -o criptografar.o
 gcc -c descriptografar.c -o descriptografar.o
 gcc -c interface.c -o interface.o
 gcc -c main.c -o main.o
 gcc -c menu.c -o menu.o
-gcc chavePublica.o criptografar.o descriptografar.o interface.o main.o menu.o -o executavel
+gcc chaves.o chavePublica.o criptografar.o descriptografar.o interface.o main.o menu.o -o executavel
 exit

--- a/interface.c
+++ b/interface.c
@@ -52,7 +52,9 @@ void i_chavePublica(int opcao) {
 		printf("Digite 'e': ");
 	} else if(opcao == 4) {
 		printf("\n");
-		printf("Gerando chave publica...");
+		printf("Gerando chave publica...\n");
+	} else if(opcao == 5) {
+		printf("Chave publica gerada.\n");
 	}
 }
 void i_criptografar(int opcao) {


### PR DESCRIPTION
A função que gera a chave pública foi finalizada adicionando mais um arquivo de referência às operações matemáticas necessárias e escrita de arquivo. 

Por padrão, a função solicita que o usuário escreva os dois primos *p* e *q* e um número relativamente primo a *(p-1)(q-1)*. Mesmo que o programa solicite essa regra para geração da chave, não há a verificação se os números fazem parte da exigência, o que fica a cargo do próprio usuário e/ou do desenvolvimento da ficture futuramente.

As duas funções adicionadas efetuam uma operação matemática básica de multiplicação e a escrita 
da chave pública seguindo o seguinte padrão: **(n,e)**, onde *n* e *e* são *p.q* e *mdc(e, (p-1)(q-1))*, respectivamente.

Para mais detalhes, ver comentários nos códigos e commits.